### PR TITLE
Update image URL of Ellen's image

### DIFF
--- a/blogs/ellenschwartau.com.json
+++ b/blogs/ellenschwartau.com.json
@@ -4,7 +4,7 @@
   "type": "blog",
   "url": "https://ellenschwartau.com",
   "rss_feed": "http://ellenschwartau.com/feed/",
-  "photo_url": "https://ellenschwartau.com/3dcb1d37-6c2d-41ea-88c1-5dd8f31765e5/",
+  "photo_url": "https://ellenschwartau.files.wordpress.com/2021/09/3dcb1d37-6c2d-41ea-88c1-5dd8f31765e5.jpg?w=540",
   "description": "Short description of what you blog about",
   "language": "en, de",
   "authors": [


### PR DESCRIPTION
@ellenschwartau ich habe heute eine "Tiles"-Übersicht der Blogs (zusätzlich zu der Liste) erstellt und dabei ist mir aufgefallen, dass deine `photo_url` nicht ganz gepasst hat. Ich wollte sichergehen, dass du mit dem Update OK bist (oder ob es bei WordPress eine andere Möglichkeit gibt) - gib mir einfach einen kurzen 👍 wenn es passt ☺️