### PR TITLE
feat: adopt one-file-per-content model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,19 +10,19 @@ With your submission, you agree that these entries will be used for the [PyLadie
 
  - [ ] The entry will be added to the [blogs/](blogs/) folder.
  - [ ] The filename of the entry ends with `.json'.
- - [ ] The json contains at least 
-     - [ ] title (blog title)
-     - [ ] type ("blog" or "youtube")
-     - [ ] url (blog URL)
-     - [ ] rss_feed (if you wish to have your blog posts being promoted by the Mastodon bot; the RSS feed should be for Python-related posts)
-     - [ ] rss_feed_youtube (if you wish to have your YouTube channel being promoted by the Mastodon bot; the RSS feed should be for Python-related videos)
+ - [ ] **One file = one piece of content.** If you have both a blog and a YouTube channel (or a podcast), please add a separate file for each. The same author can appear in multiple files.
+ - [ ] The json contains at least
+     - [ ] title (title of the content)
+     - [ ] type (one of `"blog"`, `"youtube"`, `"podcast"`)
+     - [ ] url (URL of the content)
+     - [ ] rss_feed (RSS feed for the content; required if you want it promoted by the Mastodon/Bluesky bot. For a `youtube` entry this is the channel/playlist feed; for a `blog` entry this is your blog's Python-related feed; for a `podcast` entry this is the podcast feed.)
      - [ ] photo_url (logo or profile)
      - [ ] language (one of the [ISO 639-1 language codes](https://www.w3schools.com/tags/ref_language_codes.asp))
      - [ ] authors (list of authors)
 
 # Contribution Details
 
-All blogs are listed in the [blogs](blogs/) folder, where each blog is in its own json file. These files will be used to render a table on the upcoming redesigned R-Ladies website. Follow the instructions below to add to the list. If you have any problems, please create an issue so we can help you.
+All content is listed in the [blogs](blogs/) folder, where each piece of content lives in its own json file. One file describes one blog, one YouTube channel, or one podcast — never several at once. If a contributor has both a blog and a YouTube channel, they will have two files. Follow the instructions below to add to the list. If you have any problems, please create an issue so we can help you.
 
 Depending on how you are most comfortable, there are several ways to add new entries. 
 
@@ -32,13 +32,19 @@ If you're not familiar with JSON, you can [open an issue](https://github.com/cos
 
 ## Option 2: Create a New File
 
-Create a new file in the [blogs/](blogs/) folder by [using this link](https://github.com/cosimameyer/awesome-pyladies-blogs/new/main/?filename=blogs/your-blog-url.com.json&value=%7B%0A%20%20%22title%22%3A%20%22Your%20title%22%2C%20%2F%2Frequired%0A%20%20%22subtitle%22%3A%20%22subtitle%20or%20tagline%22%2C%20%2F%2Foptional%0A%20%20%22type%22%3A%20%22blog%22%2C%20%2F%2Frequired%0A%20%20%22url%22%3A%20%22https%3A%2F%2Fyour_blog.com%22%2C%20%2F%2Frequired%0A%20%20%22photo_url%22%3A%20%22https%3A%2F%2Fyour_blog.com%2Fyour_photo.png%22%2C%20%2F%2Frequired%0A%20%20%22description%22%3A%20%22Short%20description%20of%20what%20you%20blog%20about%22%2C%0A%20%20%22language%22%3A%20%22en%22%2C%20%2F%2Frequired%0A%20%20%22rss_feed%22%3A%20%22%5Burl%5D%2Ffile.xml%22%2C%20%2F%2Frequired%20if%20you%20want%20your%20feed%20to%20be%20promoted%20on%20Mastodon%0A%20%20%22rss_feed_youtube%22%3A%20%22%5Burl%5D%3Dchannel_or_playlist_id%22%2C%20%2F%2Frequired%20if%20you%20want%20your%20feed%20to%20be%20promoted%20on%20Mastodon%0A%20%20%22authors%22%3A%20%5B%20%2F%2Frequired%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22name%22%3A%20%22Your%20Name%22%2C%20%2F%2Frequired%0A%20%20%20%20%20%20%22social_media%22%3A%20%5B%7B%0A%20%20%20%20%20%20%20%20%20%22twitter%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22mastodon%22%3A%20%22%40username%40server.org%22%2C%0A%20%20%20%20%20%20%20%20%20%22github%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22instagram%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22youtube%22%3A%20%22username%2Fend-url%22%2C%0A%20%20%20%20%20%20%20%20%20%22tiktok%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22periscope%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22researchgate%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22website%22%3A%20%22url%22%2C%0A%20%20%20%20%20%20%20%20%20%22linkedin%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22facebook%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22orcid%22%3A%20%22member%20number%22%2C%0A%20%20%20%20%20%20%20%20%20%22meetup%22%3A%20%22end-url%22%0A%20%20%20%20%20%20%7D%5D%0A%20%20%20%20%7D%0A%20%20%5D%0A%7D).
+Create a new file in the [blogs/](blogs/) folder by [using this link](https://github.com/cosimameyer/awesome-pyladies-blogs/new/main/?filename=blogs/your-blog-url.com.json&value=%7B%0A%20%20%22title%22%3A%20%22Your%20title%22%2C%20//required%0A%20%20%22subtitle%22%3A%20%22subtitle%20or%20tagline%22%2C%20//optional%0A%20%20%22type%22%3A%20%22blog%22%2C%20//required%3A%20one%20of%20%22blog%22%2C%20%22youtube%22%2C%20%22podcast%22%0A%20%20%22url%22%3A%20%22https%3A//your_blog.com%22%2C%20//required%0A%20%20%22photo_url%22%3A%20%22https%3A//your_blog.com/your_photo.png%22%2C%20//required%0A%20%20%22description%22%3A%20%22Short%20description%20of%20what%20you%20blog%20about%22%2C%0A%20%20%22language%22%3A%20%22en%22%2C%20//required%0A%20%20%22rss_feed%22%3A%20%22%5Burl%5D/file.xml%22%2C%20//required%20if%20you%20want%20your%20feed%20to%20be%20promoted%20by%20the%20bot%0A%20%20%22authors%22%3A%20%5B%20//required%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22name%22%3A%20%22Your%20Name%22%2C%20//required%0A%20%20%20%20%20%20%22social_media%22%3A%20%5B%7B%0A%20%20%20%20%20%20%20%20%20%22twitter%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22mastodon%22%3A%20%22%40username%40server.org%22%2C%0A%20%20%20%20%20%20%20%20%20%22bluesky%22%3A%20%22%40username.bsky.social%22%2C%0A%20%20%20%20%20%20%20%20%20%22github%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22instagram%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22youtube%22%3A%20%22username/end-url%22%2C%0A%20%20%20%20%20%20%20%20%20%22tiktok%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22website%22%3A%20%22url%22%2C%0A%20%20%20%20%20%20%20%20%20%22linkedin%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22facebook%22%3A%20%22username%22%2C%0A%20%20%20%20%20%20%20%20%20%22orcid%22%3A%20%22member%20number%22%2C%0A%20%20%20%20%20%20%20%20%20%22meetup%22%3A%20%22end-url%22%0A%20%20%20%20%20%20%7D%5D%0A%20%20%20%20%7D%0A%20%20%5D%0A%7D).
 
 This link will fork the repository to your user account, and initiate a new file with some template content in it. After filling the file, please [create a PR to the main branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
 
 ### File Name
 
-The name of the file should be the site url (without `www` or `http(s)://` . This way we can ensure each file has a unique name and that duplication does not happen.
+The name of the file should be the URL of the content itself, without `www` or `http(s)://`. This way each file has a unique name and we avoid duplicates.
+
+- For a blog: use the blog's domain, e.g. `cosimameyer.com.json`.
+- For a YouTube channel: use the channel URL, e.g. `youtube.com.@PyLadiesBerlin.json`.
+- For a podcast: use the podcast feed/landing-page URL.
+
+If the same person has both a blog and a YouTube channel, they get **two files** — one for each — and the same `authors` block can appear in both.
 
 ### File Content
 
@@ -55,9 +61,15 @@ The photo url you provide will be displayed as your blogs thumbnail.
 This may be a picture of you, or if you have a logo for your blog/website, it may be best to use this in stead.
 
 
-#### RSS Feed Website
+#### RSS Feed
 
-Please add a content-specific feed in `rss_feed`. Ideally, you have a specific RSS feed for Python-related posts. A title-based RSS feed is fine.
+The single `rss_feed` field is used for every content type — the bot picks the right behavior based on `type`.
+
+- For `type: "blog"`: a feed of your Python-related posts (a category/tag feed is best; a title-filtered feed works too).
+- For `type: "youtube"`: the YouTube channel or playlist feed (see ["RSS feed for YouTube videos"](#rss-feed-for-youtube-videos) below).
+- For `type: "podcast"`: the podcast's RSS feed.
+
+For blog feeds specifically, ideally you have a Python-only feed. A title-based RSS feed is fine.
 
 Depending on how your website is set up, the implementation may differ. If you need more input on how to get your RSS, have a look [here](https://zapier.com/blog/how-to-find-rss-feed-url/). If you want to check how your RSS looks like, you can use [simple pie](https://simplepie.org/demo/). We collected a few of the most common approaches below: 
 
@@ -102,11 +114,11 @@ Medium nicely describes on their website how to [get your RSS feed](https://help
 
 #### RSS feed for YouTube videos
 
-The channel or playlist RSS feed will be used to build the RSS feed for your YouTube videos. You first need to get your channel or playlist ID. How to add get them is described [here](https://www.youtube.com/watch?v=vdk8dx08ExU). 
-In the last step, you need to assemble them together with the base URL:
+For a YouTube entry, set `type: "youtube"` and put the channel or playlist feed URL in `rss_feed`. You first need to get your channel or playlist ID. How to get them is described [here](https://www.youtube.com/watch?v=vdk8dx08ExU).
+Assemble the feed URL together with the base URL:
 
-- For *channels*: `https://www.youtube.com/feeds/videos.xml?channel_id=` + `CHANNEL_ID` 
-- For *playlists*: `https://www.youtube.com/feeds/videos.xml?paylist_id=` + `PLAYLIST_ID` 
+- For *channels*: `https://www.youtube.com/feeds/videos.xml?channel_id=` + `CHANNEL_ID`
+- For *playlists*: `https://www.youtube.com/feeds/videos.xml?playlist_id=` + `PLAYLIST_ID`
 
 #### Authors
 

--- a/blogs/pyladies-berlin.json
+++ b/blogs/pyladies-berlin.json
@@ -4,7 +4,7 @@
     "url": "https://www.youtube.com/@PyLadiesBerlin",
     "photo_url": "https://yt3.googleusercontent.com/ytc/AIdro_kXbyv32bPfyTn5CDr9e3yyqOXzUjNfumZKtpxeRNDHcw=s160-c-k-c0x00ffffff-no-rj",
     "language": "en",
-    "rss_feed_youtube": "https://www.youtube.com/feeds/videos.xml?channel_id=UCVlzy-BMSYReFD0YnTzoh7w",
+    "rss_feed": "https://www.youtube.com/feeds/videos.xml?channel_id=UCVlzy-BMSYReFD0YnTzoh7w",
     "authors": [
         {
             "name": "PyLadies Berlin",

--- a/blogs/pyladies-blr.json
+++ b/blogs/pyladies-blr.json
@@ -3,7 +3,7 @@
     "type": "youtube",
     "url": "https://www.youtube.com/@pyladiesbengaluru7366",
     "photo_url": "https://raw.githubusercontent.com/cosimameyer/awesome-pyladies-blogs/main/img/pyladies_blr_logo.jpeg",
-    "rss_feed_youtube": "https://www.youtube.com/feeds/videos.xml?channel_id=UCRF8Cf4Ppe4OFed4zbgujjg",
+    "rss_feed": "https://www.youtube.com/feeds/videos.xml?channel_id=UCRF8Cf4Ppe4OFed4zbgujjg",
     "language": "en", 
     "authors": [ 
       {

--- a/blogs/pyladies-hamburg.json
+++ b/blogs/pyladies-hamburg.json
@@ -4,7 +4,7 @@
     "url": "https://www.youtube.com/@HamburgPyLadies",
     "photo_url": "https://yt3.googleusercontent.com/Fh10PC7hmhI-a7vvzqClrGbVWXFm2GoXSOPfCVvFcw8uOSTnY9-yVfOOM3Jk32aagC7i0df3uA=s160-c-k-c0x00ffffff-no-rj",
     "language": "en",
-    "rss_feed_youtube": "https://www.youtube.com/feeds/videos.xml?channel_id=UC3RXyjipkLNG8HhVAzpZBCg",
+    "rss_feed": "https://www.youtube.com/feeds/videos.xml?channel_id=UC3RXyjipkLNG8HhVAzpZBCg",
     "authors": [
         {
             "name": "PyLadies Hamburg",

--- a/blogs/pyladies-london.json
+++ b/blogs/pyladies-london.json
@@ -4,7 +4,7 @@
   "url": "https://www.youtube.com/@pyladieslondon2675",
   "photo_url": "https://pbs.twimg.com/profile_images/1092801659120562182/uBJeapSU_400x400.jpg", 
   "language": "en", 
-  "rss_feed_youtube": "https://www.youtube.com/feeds/videos.xml?channel_id=UCyyvi0HywaHZHafPUdQB38g", 
+  "rss_feed": "https://www.youtube.com/feeds/videos.xml?channel_id=UCyyvi0HywaHZHafPUdQB38g", 
   "authors": [ 
     {
       "name": "PyLadies London",

--- a/blogs/pyladies-soflo.json
+++ b/blogs/pyladies-soflo.json
@@ -5,7 +5,7 @@
   "photo_url": "https://yt3.googleusercontent.com/d0Q0c1jMSCBrfIGhWgs25pBWmym2UPZO3ex5NiAK6yhwM71AUDfyyAmeoe4xh5-sGuHRz800pw=s176-c-k-c0x00ffffff-no-rj",
   "description": "PyLadies SoFlo YouTube channel. PyLadies SoFlo is a mentoring group with a focus on nurturing gender diversity in the South Florida Python community.",
   "language": "en",
-  "rss_feed_youtube": "https://www.youtube.com/feeds/videos.xml?channel_id=UCUPLdokEtQlQmbaW9UkJEVQ",
+  "rss_feed": "https://www.youtube.com/feeds/videos.xml?channel_id=UCUPLdokEtQlQmbaW9UkJEVQ",
   "authors": [ 
     {
       "name": "PyLadies SoFlo",

--- a/scripts/.entry_schema.json
+++ b/scripts/.entry_schema.json
@@ -5,7 +5,10 @@
     "title": {"type": "string"},
     "url":   {"type": "string"},
     "rss_feed": {"type": "string"},
-    "type":  {"type": "string"},
+    "type":  {
+      "type": "string",
+      "enum": ["blog", "youtube", "podcast"]
+    },
     "photo_url":   {"type": "string"},
     "description": {"type": "string"},
     "language":    {"type": "string"},
@@ -24,6 +27,7 @@
                   "properties": {
                     "twitter":      {"type": "string"},
                     "mastodon":     {"type": "string"},
+                    "bluesky":      {"type": "string"},
                     "linkedin":     {"type": "string"},
                     "facebook":     {"type": "string"},
                     "github":       {"type": "string"},


### PR DESCRIPTION
- Rename rss_feed_youtube -> rss_feed in 5 YouTube entries
- Enforce type enum (blog, youtube, podcast) in JSON schema
- Add bluesky to schema social_media properties
- Update CONTRIBUTING.md: one-file-per-content rule, unified rss_feed docs, updated file-naming guidance and new-file template