### PR TITLE
Add Thea's content and introduce Software category

### DIFF
--- a/data/content/blog.thea.codes.json
+++ b/data/content/blog.thea.codes.json
@@ -1,0 +1,19 @@
+{
+  "title": "Thea's blog",
+  "type": "blog",
+  "url": "https://blog.thea.codes",
+  "photo_url": "https://github.com/theacodes.png",
+  "language": "en",
+  "authors": [
+    {
+      "name": "Thea Flowers",
+      "social_media": [{
+        "github": "theacodes",
+        "twitter": "theacodes",
+        "website": "https://thea.codes/",
+        "mastodon": "stargirl@hachyderm.io",
+        "bluesky": "theacodes.bsky.social"
+      }]
+    }
+  ]
+}

--- a/data/packages/flask-talisman.json
+++ b/data/packages/flask-talisman.json
@@ -1,0 +1,31 @@
+{
+  "name": "flask-talisman",
+  "description": "A small Flask extension that handles HTTP security headers for you.",
+  "logo_url": null,
+  "repo_url": "https://github.com/wntrblm/flask-talisman",
+  "pypi_url": "https://pypi.org/project/flask-talisman/",
+  "maintainers": [
+    {
+      "name": "Thea Flowers",
+      "social_media": [{
+        "github": "theacodes",
+        "twitter": "theacodes",
+        "website": "https://thea.codes/",
+        "mastodon": "stargirl@hachyderm.io",
+        "bluesky": "theacodes.bsky.social"
+      }]
+    },
+    {
+      "name": "jonakemon",
+      "social_media": [{
+        "github": "jonakemon"
+      }]
+    },
+    {
+      "name": "Jannis Leidel",
+      "social_media": [{
+        "github": "jezdez"
+      }]
+    }
+  ]
+}

--- a/data/packages/nox.json
+++ b/data/packages/nox.json
@@ -1,0 +1,49 @@
+{
+  "name": "Nox",
+  "description": "Flexible test automation for Python.",
+  "logo_url": "https://raw.githubusercontent.com/wntrblm/nox/refs/heads/main/docs/_static/alice.png",
+  "repo_url": "https://github.com/wntrblm/nox",
+  "pypi_url": "https://pypi.org/project/nox/",
+  "maintainers": [
+    {
+      "name": "Thea Flowers",
+      "social_media": [{
+        "github": "theacodes",
+        "twitter": "theacodes",
+        "website": "https://thea.codes/",
+        "mastodon": "stargirl@hachyderm.io",
+        "bluesky": "theacodes.bsky.social"
+      }]
+    },
+    {
+      "name": "Danny Hermes",
+      "social_media": [{
+        "github": "bossylobster"
+      }]
+    },
+    {
+      "name": "Chris Wilcox",
+      "social_media": [{
+        "github": "crwilcox"
+      }]
+    },
+    {
+      "name": "Henry Schreiner",
+      "social_media": [{
+        "github": "henryiii"
+      }]
+    },
+    {
+      "name": "Luke Sneeringer",
+      "social_media": [{
+        "github": "lukesneeringer"
+      }]
+    },
+    {
+      "name": "Diego Ramirez",
+      "social_media": [{
+        "github": "stsewd"
+      }]
+    }
+  ]
+}

--- a/data/software/witch-hazel.json
+++ b/data/software/witch-hazel.json
@@ -1,0 +1,18 @@
+{
+  "name": "Witch Hazel",
+  "description": "A color scheme inspired by magic and nature.",
+  "website_url": "https://witchhazel.thea.codes",
+  "repo_url": "https://github.com/theacodes/witchhazel",
+  "maintainers": [
+    {
+      "name": "Thea Flowers",
+      "social_media": [{
+        "github": "theacodes",
+        "twitter": "theacodes",
+        "website": "https://thea.codes/",
+        "mastodon": "stargirl@hachyderm.io",
+        "bluesky": "theacodes.bsky.social"
+      }]
+    }
+  ]
+}

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -10,6 +10,7 @@ import urllib.parse
 fallback_images_dir = "img/fallback_images/"
 content_directory = "data/content/"
 packages_directory = "data/packages/"
+software_directory = "data/software/"
 
 if os.path.exists(fallback_images_dir):
     fallback_images = [f for f in os.listdir(fallback_images_dir) if f.lower().endswith(('.png', '.jpg', '.jpeg', '.gif'))]
@@ -95,6 +96,7 @@ def load_json_files(path):
 
 content_data = load_json_files(content_directory)
 package_data = load_json_files(packages_directory)
+software_data = load_json_files(software_directory)
 
 content_data.sort(key=lambda x: x.get('authors', [{}])[0].get('name', 'Unknown'))
 
@@ -119,7 +121,7 @@ if count % cols != 0: grid_entries += "| " * (cols - (count % cols)) + "\n|"
 full_table = f"{'| ' * cols}|\n{'|:---:' * cols}|\n|{grid_entries}"
 
 # 3. Build Categorized Lists
-blogs, youtube, podcasts, libraries = [], [], [], []
+blogs, youtube, podcasts, libraries, other_software = [], [], [], [], []
 
 def format_entry_line(entry, is_package=False):
     # Surgical fix for authors vs maintainers
@@ -128,11 +130,11 @@ def format_entry_line(entry, is_package=False):
         authors_str = "Unknown"
     else:
         authors_str = ", ".join([a.get("name", "Unknown") for a in authors_list])
-    
+
     # Surgical fix for naming and URLs in packages
     title = entry.get('title') or entry.get('name', 'Untitled')
-    url = entry.get('url') or entry.get('repo_url') or '#'
-    
+    url = entry.get('url') or entry.get('website_url') or entry.get('repo_url') or '#'
+
     return f"- [{title}]({url}) by {authors_str}"
 
 for entry in content_data:
@@ -145,12 +147,18 @@ for entry in content_data:
 for entry in package_data:
     libraries.append(format_entry_line(entry, is_package=True))
 
+for entry in software_data:
+    other_software.append(format_entry_line(entry))
+
 # 4. Generate README
 sections = []
 if blogs: sections.extend(["### Blogs", os.linesep.join(blogs)])
 if youtube: sections.extend(["### YouTube Channels", os.linesep.join(youtube)])
 if podcasts: sections.extend(["### Podcasts", os.linesep.join(podcasts)])
-if libraries: sections.extend(["### Python Libraries", os.linesep.join(libraries)])
+if libraries or other_software:
+    sections.append("### Software")
+    if libraries: sections.extend(["#### Python Libraries", os.linesep.join(libraries)])
+    if other_software: sections.extend(["#### Other Software", os.linesep.join(other_software)])
 
 readme_content = f"""
 # Awesome PyLadies' Repository  


### PR DESCRIPTION
- Add Thea's blog (blog.thea.codes) to data/content
- Add flask-talisman and nox to data/packages (from PR #114)
- Add Witch Hazel color scheme to new data/software directory
- Restructure README generator: 'Software' is now a parent section with 'Python Libraries' and 'Other Software' as subcategories, accommodating tools that are not Python packages