### PR TITLE
Fix package title casing: gidgethub, expfactory, pokemon, nox

### DIFF
--- a/data/packages/axe-playwright-python.json
+++ b/data/packages/axe-playwright-python.json
@@ -1,6 +1,6 @@
 {
     "name": "axe-playwright-python",
-    "title": "Axe Playwright Python",
+    "title": "axe-playwright-python",
     "description": "Automated web accessibility testing using axe-core engine and Playwright.",
     "logo_url": null,
     "repo_url": "https://github.com/pamelafox/axe-playwright-python",

--- a/data/packages/expfactory.json
+++ b/data/packages/expfactory.json
@@ -1,6 +1,6 @@
 {
   "name": "expfactory",
-  "title": "Expfactory",
+  "title": "expfactory",
   "description": "Software to generate a reproducible container with a battery of experiments.",
   "logo_url": "https://raw.githubusercontent.com/expfactory/expfactory/refs/heads/master/docs/img/expfactoryticketyellow.png",
   "repo_url": "https://github.com/expfactory/expfactory",

--- a/data/packages/flask-talisman.json
+++ b/data/packages/flask-talisman.json
@@ -1,6 +1,6 @@
 {
   "name": "flask-talisman",
-  "title": "Flask-Talisman",
+  "title": "flask-talisman",
   "description": "A small Flask extension that handles HTTP security headers for you.",
   "logo_url": null,
   "repo_url": "https://github.com/wntrblm/flask-talisman",

--- a/data/packages/gidgethub.json
+++ b/data/packages/gidgethub.json
@@ -1,6 +1,6 @@
 {
 "name": "gidgethub",
-"title": "Gidgethub",
+"title": "gidgethub",
 "description": "An async GitHub API library for Python.",
 "logo_url": null,
 "repo_url": "https://github.com/gidgethub/gidgethub",

--- a/data/packages/kedro.json
+++ b/data/packages/kedro.json
@@ -1,6 +1,6 @@
 {
-    "name": "Kedro",
-    "title": "Kedro",
+    "name": "kedro",
+    "title": "kedro",
     "description": "An open-source Python framework for creating reproducible, maintainable and modular data science code.",
     "logo_url": "https://raw.githubusercontent.com/kedro-org/kedro/main/docs/source/_static/kedro_logo.png",
     "repo_url": "https://github.com/kedro-org/kedro",

--- a/data/packages/nox.json
+++ b/data/packages/nox.json
@@ -1,6 +1,6 @@
 {
-  "name": "Nox",
-  "title": "Nox",
+  "name": "nox",
+  "title": "nox",
   "description": "Flexible test automation for Python.",
   "logo_url": "https://raw.githubusercontent.com/wntrblm/nox/refs/heads/main/docs/_static/alice.png",
   "repo_url": "https://github.com/wntrblm/nox",

--- a/data/packages/overviewpy.json
+++ b/data/packages/overviewpy.json
@@ -1,6 +1,6 @@
 {
     "name": "overviewpy",
-    "title": "OverviewPy",
+    "title": "overviewpy",
     "description": "Easily Extracting Information About Your Data",
     "logo_url": "https://raw.githubusercontent.com/cosimameyer/overviewpy/main/docs/img/overviewpy.png",
     "repo_url": "https://github.com/cosimameyer/overviewpy",

--- a/data/packages/pokemon.json
+++ b/data/packages/pokemon.json
@@ -1,6 +1,6 @@
 {
   "name": "pokemon",
-  "title": "Pokemon",
+  "title": "pokemon",
   "description": "ascii database of pokemon in Python!",
   "logo_url": "https://raw.githubusercontent.com/vsoch/pokemon/master/img/avatar.png",
   "repo_url": "https://github.com/vsoch/pokemon",

--- a/data/packages/pull-request-action.json
+++ b/data/packages/pull-request-action.json
@@ -1,6 +1,6 @@
 {
   "name": "pull-request-action",
-  "title": "Pull Request Action",
+  "title": "pull-request-action",
   "description": "GitHub Action to open a pull request when a branch is pushed or updated.",
   "logo_url": null,
   "repo_url": "https://github.com/vsoch/pull-request-action",

--- a/data/packages/roctet.json
+++ b/data/packages/roctet.json
@@ -1,6 +1,6 @@
 {
     "name": "roctet",
-    "title": "Roctet",
+    "title": "roctet",
     "description": "Generate diverse score-target datasets with the same AUROC value, ala Anscombe's Quartet",
     "logo_url": null,
     "repo_url": "https://github.com/emilyriederer/roctet",

--- a/data/packages/singularity-compose.json
+++ b/data/packages/singularity-compose.json
@@ -1,6 +1,6 @@
 {
   "name": "singularity-compose",
-  "title": "Singularity Compose",
+  "title": "singularity-compose",
   "description": "A simple orchestration library for Singularity containers, akin to Docker Compose.",
   "logo_url": null,
   "repo_url": "https://github.com/singularityhub/singularity-compose",

--- a/data/packages/singularity-hpc.json
+++ b/data/packages/singularity-hpc.json
@@ -1,6 +1,6 @@
 {
   "name": "singularity-hpc",
-  "title": "Singularity HPC",
+  "title": "singularity-hpc",
   "description": "Local filesystem registry for containers (intended for HPC) using Lmod or Environment Modules.",
   "logo_url": "https://raw.githubusercontent.com/singularityhub/singularity-hpc/refs/heads/main/docs/assets/img/shpc.svg",
   "repo_url": "https://github.com/singularityhub/singularity-hpc",


### PR DESCRIPTION
Fixes title fields to match the original lowercase PyPI naming instead of auto-capitalized versions.