### PR TITLE
feat: add PyLadies Shizuoka chapter

### DIFF
--- a/data/chapters/pyladies-shizuoka-japan.json
+++ b/data/chapters/pyladies-shizuoka-japan.json
@@ -1,0 +1,7 @@
+{
+  "name": "PyLadies Shizuoka",
+  "city": "Shizuoka",
+  "country": "Japan",
+  "email": "shizuoka@pyladies.com",
+  "website": "https://pyladiesshizuoka.github.io/"
+}

--- a/data/chapters/pyladies-shizuoka-japan.json
+++ b/data/chapters/pyladies-shizuoka-japan.json
@@ -8,5 +8,7 @@
     {
       "github": "PyLadiesShizuoka"
     }
-  ]
+  ],
+  "lat": 34.9751974,
+  "lon": 138.3831697
 }

--- a/data/chapters/pyladies-shizuoka-japan.json
+++ b/data/chapters/pyladies-shizuoka-japan.json
@@ -3,5 +3,10 @@
   "city": "Shizuoka",
   "country": "Japan",
   "email": "shizuoka@pyladies.com",
-  "website": "https://pyladiesshizuoka.github.io/"
+  "website": "https://pyladiesshizuoka.github.io/",
+  "social_media": [
+    {
+      "github": "PyLadiesShizuoka"
+    }
+  ]
 }


### PR DESCRIPTION
## What's been added

I'd love to feature **PyLadies Shizuoka** (Shizuoka, Japan) in the [awesome-pyladies-creations](https://github.com/cosimameyer/awesome-pyladies-creations) community directory!

This PR was created through a semi-automated search and includes:
- `data/chapters/pyladies-shizuoka-japan.json` — chapter entry with location and social links

## For the chapter

Hi PyLadies Shizuoka team! 👋 Could you take a quick look and let us know:

*(Note: we couldn't find a GitHub account for this chapter — if you have one, feel free to share it!)*

- Does everything look correct (name, location, social links)?
- Are you happy for us to merge this? Or would you prefer we close the PR — both outcomes are totally fine!

No rush at all. 💜