### PR TITLE
fix: use default merge commit checkout in validate-person-consistency workflow

### DIFF
--- a/.github/workflows/validate-person-consistency.yml
+++ b/.github/workflows/validate-person-consistency.yml
@@ -19,8 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

- Removes the explicit `ref: ${{ github.event.pull_request.head.sha }}` override from the checkout step
- By default, `actions/checkout` on `pull_request` events checks out the **merge commit** (PR head merged into base), which includes all files from `main` — including `scripts/validate_person_consistency.py`
- The explicit head SHA checkout was causing the workflow to fail for PRs whose branch was created before the validation script was added to `main`

Fixes the error reported in [#323](https://github.com/cosimameyer/awesome-pyladies-creations/pull/323#issuecomment-4507681423).