### PR TITLE
fix: checkout base branch and merge PR in CI workflows

### DIFF
--- a/.github/workflows/check_readme_on_pr.yml
+++ b/.github/workflows/check_readme_on_pr.yml
@@ -16,9 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Use SHA (immutable) instead of ref (branch name) so checkout
-          # still works if the branch is deleted before this job runs
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+
+      - name: Merge PR changes
+        run: |
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git merge ${{ github.event.pull_request.head.sha }} --no-edit
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/validate-person-consistency.yml
+++ b/.github/workflows/validate-person-consistency.yml
@@ -19,6 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+
+      - name: Merge PR changes
+        run: |
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git merge ${{ github.event.pull_request.head.sha }} --no-edit
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Problem

Both workflows check out the PR branch head SHA, which is missing files added to `main` after the PR branch was created:

- `validate-person-consistency`: can't find `scripts/validate_person_consistency.py`
- `check-readme`: can't find `jsonschema` (the updated `requirements.txt` isn't on the PR branch)

## Fix

Instead of checking out the PR head SHA, both workflows now:
1. Check out the **base branch** (`main`) — always has the latest scripts and `requirements.txt`
2. Merge the PR's head SHA on top — applies the PR's data changes

This is equivalent to the merge commit, but computed fresh so it's never stale.

Fixes the failures on [#323](https://github.com/cosimameyer/awesome-pyladies-creations/pull/323).

Also closes #334 (the debug PR is no longer needed).