### PR TITLE
fix: checkout base branch and merge PR changes in CI workflows

### DIFF
--- a/.github/workflows/check_readme_on_pr.yml
+++ b/.github/workflows/check_readme_on_pr.yml
@@ -16,9 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Use SHA (immutable) instead of ref (branch name) so checkout
-          # still works if the branch is deleted before this job runs
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+
+      - name: Merge PR changes
+        run: |
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git merge --no-commit ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/validate-person-consistency.yml
+++ b/.github/workflows/validate-person-consistency.yml
@@ -19,6 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          fetch-depth: 0
+
+      - name: Merge PR changes
+        run: |
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          git merge --no-commit ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-python@v5
         with:
@@ -29,11 +37,7 @@ jobs:
         run: |
           set +e
           python scripts/validate_person_consistency.py > /tmp/consistency_output.txt 2>&1
-          EXIT_CODE=$?
-          echo "--- script output ---"
-          cat /tmp/consistency_output.txt
-          echo "--- exit code: $EXIT_CODE ---"
-          echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
+          echo "exit_code=$?" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Post PR comment on inconsistency


### PR DESCRIPTION
## Summary

- Reverts the debug logging added in #334
- Fixes the `git merge` identity error from #335 by using `--no-commit` (no commit is created, so no git identity is needed)
- Fixes both `validate-person-consistency` and `check-readme` workflows to check out the **base branch** first, then merge the PR's changes on top — so scripts and `requirements.txt` are always from `main` regardless of when the PR branch was created

Supersedes #335.