### PR TITLE
fix: apply PR changes via git checkout instead of git merge

### DIFF
--- a/.github/workflows/check_readme_on_pr.yml
+++ b/.github/workflows/check_readme_on_pr.yml
@@ -19,10 +19,10 @@ jobs:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
 
-      - name: Merge PR changes
+      - name: Apply PR changes
         run: |
           git fetch origin ${{ github.event.pull_request.head.sha }}
-          git merge --no-commit ${{ github.event.pull_request.head.sha }}
+          git diff --name-only --diff-filter=ACM HEAD FETCH_HEAD | xargs -r git checkout FETCH_HEAD --
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/validate-person-consistency.yml
+++ b/.github/workflows/validate-person-consistency.yml
@@ -23,10 +23,10 @@ jobs:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
 
-      - name: Merge PR changes
+      - name: Apply PR changes
         run: |
           git fetch origin ${{ github.event.pull_request.head.sha }}
-          git merge --no-commit ${{ github.event.pull_request.head.sha }}
+          git diff --name-only --diff-filter=ACM HEAD FETCH_HEAD | xargs -r git checkout FETCH_HEAD --
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Problem

`git merge --no-commit` still requires a git identity on the runner, causing:
```
fatal: empty ident name (for <runner@...>) not allowed
```

## Fix

Replace `git merge --no-commit` with a targeted `git checkout` of only the files changed in the PR:

```bash
git diff --name-only --diff-filter=ACM HEAD FETCH_HEAD | xargs -r git checkout FETCH_HEAD --
```

This overlays the PR's added/modified files on top of the base branch checkout. No commit is created, so no git identity is needed.

Supersedes #336.