### PR TITLE
fix: only checkout data/ from PR to preserve scripts and requirements from main

### DIFF
--- a/.github/workflows/check_readme_on_pr.yml
+++ b/.github/workflows/check_readme_on_pr.yml
@@ -19,10 +19,10 @@ jobs:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
 
-      - name: Apply PR changes
+      - name: Apply PR data changes
         run: |
           git fetch origin ${{ github.event.pull_request.head.sha }}
-          git diff --name-only --diff-filter=ACM HEAD FETCH_HEAD | xargs -r git checkout FETCH_HEAD --
+          git checkout FETCH_HEAD -- data/
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/validate-person-consistency.yml
+++ b/.github/workflows/validate-person-consistency.yml
@@ -23,10 +23,10 @@ jobs:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
 
-      - name: Apply PR changes
+      - name: Apply PR data changes
         run: |
           git fetch origin ${{ github.event.pull_request.head.sha }}
-          git diff --name-only --diff-filter=ACM HEAD FETCH_HEAD | xargs -r git checkout FETCH_HEAD --
+          git checkout FETCH_HEAD -- data/
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Problem

The previous approach (`git diff ... | xargs git checkout FETCH_HEAD --`) was checking out **all** changed files from the PR branch, including `requirements.txt` if it differed from main. This overwrote main's `requirements.txt` (which has `jsonschema`) with the PR branch's older version (which doesn't), causing `ModuleNotFoundError: No module named 'jsonschema'`.

## Fix

Explicitly only check out `data/` from the PR branch head. Scripts, `requirements.txt`, and everything else always come from `main`. Since both workflows only validate data files, this is exactly the right scope.

Supersedes #337.