### PR TITLE
feat: update PyPodcats entry with description, image, and primary author flag

### DIFF
--- a/data/content/pypodcats.live.json
+++ b/data/content/pypodcats.live.json
@@ -2,12 +2,14 @@
   "title": "PyPodcats",
   "type": "podcast",
   "url": "https://pypodcats.live",
-  "photo_url": "https://github.com/pypodcats.png",
+  "photo_url": "https://pypodcats.live/images/pypodcats-2025-s_hu_97a013cd6aad38a.webp",
   "rss_feed": "https://pypodcats.live/episodes/index.xml",
+  "description": "Stories from the underrepresented group members of the Python community.",
   "language": "en",
   "authors": [
     {
       "name": "PyPodcats",
+      "primary": true,
       "social_media": [{
         "x": "pypodcats",
         "mastodon": "fosstodon.org/@pypodcats",


### PR DESCRIPTION
## Summary

- Adds a `description` field: *"Stories from the underrepresented group members of the Python community."*
- Replaces the GitHub avatar placeholder with the actual podcast image (`pypodcats-2025-s_hu_97a013cd6aad38a.webp`)
- Marks the `PyPodcats` author entry with `"primary": true` so the website can display only the show's own social links on the tile (used by the companion design PR)

--- 

@Cheukting @Mariatta @terezaif @georgically - sorry for pinging you again, but I realized that the current implementation needs more input to look good :) does this look good to you?

Here's what it looked like: 
<img width="502" height="336" alt="image" src="https://github.com/user-attachments/assets/66988e55-2e8a-4b25-9039-2e44d700cbaa" />

The change will allow me to reduce the socials to your podcast and add a description as well as an image of the podcast while still giving all of you credits for the podcast :)

