### PR TITLE
fix: podcast tiles show primary contact only; stats stay on one row

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -200,21 +200,22 @@ h1 {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0;
   padding: 20px 32px;
   background: #1e293b;
   border: 1px solid rgba(255,255,255,.1);
   border-radius: var(--radius-lg);
   margin-bottom: 40px;
-  flex-wrap: wrap;
-  gap: 4px;
+  flex-wrap: nowrap;
+  gap: 0;
 }
 
 .stat {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 8px 28px;
+  padding: 8px 18px;
+  flex-shrink: 1;
+  min-width: 0;
 }
 
 .stat-num {
@@ -232,6 +233,7 @@ h1 {
   letter-spacing: .06em;
   font-weight: 600;
   margin-top: 4px;
+  white-space: nowrap;
 }
 
 .stat-divider {

--- a/scripts/generate_site.py
+++ b/scripts/generate_site.py
@@ -310,12 +310,19 @@ def render_content_card(entry, registry=None):
     fallback    = avatar_fallback(raw_title)
     photo_src   = escape(raw_photo) if raw_photo else fallback
 
-    # Collect social icons for each author from the registry
+    # Collect social icons for each author from the registry.
+    # For podcasts, only show the primary author (marked with "primary": true, or the
+    # first author as fallback) so the tile isn't cluttered with every host's icons.
     social_icons_html = ""
     if registry:
         icons = []
         seen_authors = set()
-        for author in authors:
+        if ctype == "podcast":
+            primary = next((a for a in authors if a.get("primary")), authors[0] if authors else None)
+            display_authors = [primary] if primary else []
+        else:
+            display_authors = authors
+        for author in display_authors:
             name = author.get("name", "")
             if not name or name in seen_authors:
                 continue
@@ -536,7 +543,7 @@ def build_stats_html(n_people, n_blogs, n_youtube, n_podcasts, n_packages, n_cha
         (f"{n_people}+", "Creators"),
         (n_chapters,      "Chapters"),
         (n_blogs,         "Blogs"),
-        (n_youtube,       "YouTube Channels"),
+        (n_youtube,       "YouTube"),
         (n_podcasts,      "Podcasts"),
         (n_packages,      "Packages"),
     ]


### PR DESCRIPTION
## Summary

- **Podcast tiles**: `render_content_card` now shows social icons only for the author marked `"primary": true` (falls back to first author). For all other content types, behaviour is unchanged.
- **Stats bar**: removes the duplicate `gap` declaration, switches to `flex-wrap: nowrap` with `flex-shrink: 1` on each stat, adds `white-space: nowrap` to labels, and reduces horizontal padding (`28px → 18px`) so all stats stay on a single row. Renames *"YouTube Channels"* → *"YouTube"* to match the tab filter label and save space.

## Maintainability note

The `"primary": true` field on an author entry is the intended way to designate the main contact for a multi-host entry. If no author has it, the first author is used as fallback — so existing entries without the flag are unaffected.